### PR TITLE
Change PDF links to abstract pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,51 +5,51 @@ Implementation of papers in 100 lines of code.
 ## Implemented papers
 
 ##### [Auto-Encoding Variational Bayes]
-- Auto-Encoding Variational Bayes [[pdf]](https://arxiv.org/pdf/1312.6114.pdf)
+- Auto-Encoding Variational Bayes [[arXiv]](https://arxiv.org/abs/1312.6114)
 - *Diederik P Kingma, Max Welling*
 - `2013-12-20`
 
 ##### [Generative Adversarial Networks]
-- Generative Adversarial Networks [[pdf]](https://arxiv.org/pdf/1406.2661.pdf)
+- Generative Adversarial Networks [[arXiv]](https://arxiv.org/abs/1406.2661)
 - *Ian J. Goodfellow, Jean Pouget-Abadie, Mehdi Mirza, Bing Xu, David Warde-Farley, Sherjil Ozair, Aaron Courville, Yoshua Bengio*
 - `2014-06-10`
 
 ##### [NICE: Non-linear Independent Components Estimation]
-- NICE: Non-linear Independent Components Estimation [[pdf]](https://arxiv.org/pdf/1410.8516.pdf)
+- NICE: Non-linear Independent Components Estimation [[arXiv]](https://arxiv.org/abs/1410.8516)
 - *Laurent Dinh, David Krueger, Yoshua Bengio*
 - `2014-10-30`
 
 ##### [Variational Inference with Normalizing Flows]
-- Variational Inference with Normalizing Flows [[pdf]](https://arxiv.org/pdf/1505.05770.pdf)
+- Variational Inference with Normalizing Flows [[arXiv]](https://arxiv.org/abs/1505.05770)
 - *Danilo Jimenez Rezende, Shakir Mohamed*
 - `2015-05-21`
 
 ##### [Sequential Neural Likelihood]
-- Sequential Neural Likelihood: Fast Likelihood-free Inference with Autoregressive Flows [[pdf]](https://arxiv.org/pdf/1805.07226.pdf)
+- Sequential Neural Likelihood: Fast Likelihood-free Inference with Autoregressive Flows [[arXiv]](https://arxiv.org/abs/1805.07226)
 - *George Papamakarios, David C. Sterratt, Iain Murray*
 - `2018-05-18`
 
 ##### [Optimizing Millions of Hyperparameters by Implicit Differentiation]
-- Optimizing Millions of Hyperparameters by Implicit Differentiation [[pdf]](http://proceedings.mlr.press/v108/lorraine20a/lorraine20a.pdf)
+- Optimizing Millions of Hyperparameters by Implicit Differentiation [[PMLR]](https://proceedings.mlr.press/v108/lorraine20a)
 - *Jonathan Lorraine, Paul Vicol, David Duvenaud*
 - `2019-10-06`
 
 ##### [Fourier Features Let Networks Learn High Frequency Functions in Low Dimensional Domains]
-- Fourier Features Let Networks Learn High Frequency Functions in Low Dimensional Domains [[pdf]](https://arxiv.org/pdf/2006.10739.pdf)
+- Fourier Features Let Networks Learn High Frequency Functions in Low Dimensional Domains [[arXiv]](https://arxiv.org/abs/2006.10739)
 - *Matthew Tancik, Pratul P. Srinivasan, Ben Mildenhall, Sara Fridovich-Keil, Nithin Raghavan, Utkarsh Singhal, Ravi Ramamoorthi, Jonathan T. Barron, Ren Ng*
 - `2020-06-18`
 
 ##### [Likelihood-free MCMC with Amortized Approximate Ratio Estimators]
-- Likelihood-free MCMC with Amortized Approximate Ratio Estimators [[pdf]](http://proceedings.mlr.press/v108/lorraine20a/lorraine20a.pdf)
+- Likelihood-free MCMC with Amortized Approximate Ratio Estimators [[PMLR]](http://proceedings.mlr.press/v108/lorraine20a)
 - *Joeri Hermans, Volodimir Begy, Gilles Louppe*
 - `2020-06-26`
 
 ##### [NeRF: Representing Scenes as Neural Radiance Fields for View Synthesis]
-- NeRF: Representing Scenes as Neural Radiance Fields for View Synthesis [[pdf]](https://arxiv.org/pdf/2003.08934.pdf)
+- NeRF: Representing Scenes as Neural Radiance Fields for View Synthesis [[arXiv]](https://arxiv.org/abs/2003.08934)
 - *Ben Mildenhall, Pratul P. Srinivasan, Matthew Tancik, Jonathan T. Barron, Ravi Ramamoorthi, Ren Ng*
 - `2020-08-03`
 
 ##### [Gromov-Wasserstein Distances between Gaussian Distributions]
-- Gromov-Wasserstein Distances between Gaussian Distributions [[pdf]](https://arxiv.org/pdf/2104.07970.pdf)
+- Gromov-Wasserstein Distances between Gaussian Distributions [[arXiv]](https://arxiv.org/abs/2104.07970)
 - *Antoine Salmona, Julie Delon, Agnès Desolneux*
 - `2021-08-16`


### PR DESCRIPTION
Obviously this is a matter of taste so feel free to close if you disagree, but I prefer to link to arXiv abstract pages instead of straight to the PDF. PDFs can take very long to load and oftentimes people just want to skim the abstract to see if they're really interested.