### PR TITLE
NeRF updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+*data*
 # C extensions
 *.so
 

--- a/NeRF_Representing_Scenes_as_Neural_Radiance_Fields_for_View_Synthesis/README.md
+++ b/NeRF_Representing_Scenes_as_Neural_Radiance_Fields_for_View_Synthesis/README.md
@@ -7,6 +7,8 @@ Implementation in 100 lines of code of the paper [NeRF: Representing Scenes as N
 
 **Dataset:** [Download the training and testing datasets](https://drive.google.com/drive/folders/18bwm-RiHETRCS5yD9G00seFIcrJHIvD-?usp=sharing) and save in `data` folder.
 ```commandline
+$ conda create -n nerf --python=3.10
+$ conda activate nerf
 $ pip3 install -r requirements.txt
 $ mkdir data && cd data
 $ gdown 1hH7NhaXxIthO9-FeT16fvpf_MVIhf41J  

--- a/NeRF_Representing_Scenes_as_Neural_Radiance_Fields_for_View_Synthesis/README.md
+++ b/NeRF_Representing_Scenes_as_Neural_Radiance_Fields_for_View_Synthesis/README.md
@@ -5,9 +5,12 @@ Implementation in 100 lines of code of the paper [NeRF: Representing Scenes as N
 
 ## Usage
 
-**Dataset:** [Download the training and testing datasets](https://drive.google.com/drive/folders/18bwm-RiHETRCS5yD9G00seFIcrJHIvD-?usp=sharing).
+**Dataset:** [Download the training and testing datasets](https://drive.google.com/drive/folders/18bwm-RiHETRCS5yD9G00seFIcrJHIvD-?usp=sharing) and save in `data` folder.
 ```commandline
 $ pip3 install -r requirements.txt
+$ mkdir data && cd data
+$ gdown 1hH7NhaXxIthO9-FeT16fvpf_MVIhf41J  
+$ gdown 16M64h0KKgFKhM8hJDpqd15YWYhafUs2Q 
 $ python3 nerf.py
 ```
 

--- a/NeRF_Representing_Scenes_as_Neural_Radiance_Fields_for_View_Synthesis/nerf.py
+++ b/NeRF_Representing_Scenes_as_Neural_Radiance_Fields_for_View_Synthesis/nerf.py
@@ -139,10 +139,17 @@ def train(nerf_model, optimizer, scheduler, data_loader, device='cpu', hn=0, hf=
 
 
 if __name__ == '__main__':
-    device = 'cuda'
+    try:
+        if torch.backends.mps.is_available():
+            device = torch.device("mps")
+    except:
+        if torch.cuda.is_available():
+            device = torch.device("cuda:0")
+        else:
+            device = torch.device("cpu")
     
-    training_dataset = torch.from_numpy(np.load('training_data.pkl', allow_pickle=True))
-    testing_dataset = torch.from_numpy(np.load('testing_data.pkl', allow_pickle=True))
+    training_dataset = torch.from_numpy(np.load('data/training_data.pkl', allow_pickle=True))
+    testing_dataset = torch.from_numpy(np.load('data/testing_data.pkl', allow_pickle=True))
     model = NerfModel(hidden_dim=256).to(device)
     model_optimizer = torch.optim.Adam(model.parameters(), lr=5e-4)
     scheduler = torch.optim.lr_scheduler.MultiStepLR(model_optimizer, milestones=[2, 4, 8], gamma=0.5)

--- a/NeRF_Representing_Scenes_as_Neural_Radiance_Fields_for_View_Synthesis/requirements.txt
+++ b/NeRF_Representing_Scenes_as_Neural_Radiance_Fields_for_View_Synthesis/requirements.txt
@@ -1,4 +1,5 @@
-matplotlib==3.3.4
-numpy==1.19.5
-torch==1.7.1
-tqdm==4.48.2
+torch==2.0.0
+matplotlib
+numpy
+tqdm
+gdown


### PR DESCRIPTION
## Updates
- created a conda environment 
- updated `torch` version to `2.0.0`
- added `gdown` to requirements making it easier to fetch data
- updated `device` variable to select device based on hardware available 
- updated `README.md`
- updated `gitignore` to ignore `data` folder

## Known issues
- `mps` device currently does not support `aten::cumprod.out` but can be run using `cpu`.
Complete error
```
line 84, in compute_accumulated_transmittance
    accumulated_transmittance = torch.cumprod(alphas, 1)
NotImplementedError: The operator 'aten::cumprod.out' is not currently implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
```