### PR TITLE
Update kilo_nerf.py. Add underscores in kilo_nerf.py

### DIFF
--- a/KiloNeRF_Speeding_up_Neural_Radiance_Fields_with_Thousands_of_Tiny_MLPs/kilo_nerf.py
+++ b/KiloNeRF_Speeding_up_Neural_Radiance_Fields_with_Thousands_of_Tiny_MLPs/kilo_nerf.py
@@ -135,7 +135,7 @@ def train(nerf_model, optimizer, scheduler, data_loader, device='cpu', hn=0, hf=
     return training_loss
 
 
-if __name__ == 'main':
+if __name__ == '__main__':
     device = 'cuda'
     training_dataset = torch.from_numpy(np.load('training_data.pkl', allow_pickle=True))
     testing_dataset = torch.from_numpy(np.load('testing_data.pkl', allow_pickle=True))


### PR DESCRIPTION
There were missing underscores in the file kilo_nerf.py at line no. 138 in the statement _**_if __name__ == '__main__':_**_