### PR TITLE
better make use of the torchvision provided MNIST dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,4 +128,7 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# MNIST dataset by torchvision
+**/MNIST/raw/**
+
 .DS_Store

--- a/Density_Estimation_Using_Real_NVP/requirements.txt
+++ b/Density_Estimation_Using_Real_NVP/requirements.txt
@@ -1,5 +1,5 @@
-keras==3.10.0
-matplotlib==3.5.1
+matplotlib==3.10.7
 numpy==1.26.4
 torch==2.7.0
+torchvision==0.22.0
 tqdm==4.67.1


### PR DESCRIPTION
- better make use of the torchvision provided MNIST dataset instead of the one by keras, see: https://github.com/MaximeVandegar/Papers-in-100-Lines-of-Code/issues/26
- remove the usage of `torch.Tensor.expand` as broadcasting already takes care of the batch dimension
- replace the usage of the deprecated `torch.nn.utils.weight_norm` (since pytorch 2.1.0) with `torch.nn.utils.parametrizations.weight_norm`